### PR TITLE
Update Ubuntu wildcard

### DIFF
--- a/app-fqdn-rules.tf
+++ b/app-fqdn-rules.tf
@@ -4,6 +4,7 @@ locals {
     tcp = {
       "*.aviatrix.com" = "443"
       "aviatrix.com"   = "80"
+      "*.ubuntu.com"   = "80"
     }
     udp = {
       "dns.google.com" = "53"


### PR DESCRIPTION
added the *.ubuntu.com wildcard to the filter. This will allow the following 2 commands to work:

sudo apt-get update -y
sudo apt-get upgrade -y

## Description

_Describe the changes needed_
